### PR TITLE
Chore: Upgrade Gradle and Kotlin versions to enhance JCEF support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+/.kotlin/
 
 ### IntelliJ IDEA ###
 .idea

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,11 @@ group = "cc.moky.intellij.plugin"
 version = providers.environmentVariable("VERSION_TAG").orElse("0.0.1-beta1").get()
 
 val customChangeNotes = """
+<strong>Changes in version 1.1.1:</strong>
+<ul>
+<li>Add JCEF support detection and user prompts to guide users to switch to JBR, which supports JCEF, when JCEF is unavailable.</li>
+<li>Improve IDE compatibility settings and remove the upper limit to support future versions.</li>
+</ul>
 <strong>Changes in version 1.1.0:</strong>
 <ul>
 <li>Migrate to IntelliJ Platform Gradle Plugin 2.x</li>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,7 +65,7 @@ val customChangeNotes = """
 """.trimIndent()
 
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "2.0.21"
+    id("org.jetbrains.kotlin.jvm") version "2.2.0"
     id("org.jetbrains.intellij.platform") version "2.11.0"
 }
 
@@ -78,13 +78,21 @@ repositories {
     }
 }
 
+// Set to true to use a custom IDE for development/testing
+val customIde = false
+
 dependencies {
     intellijPlatform {
-        intellijIdeaCommunity("2022.3")
+        // Use custom ide for development/testing (comment out for CI builds)
+        if (customIde) {
+            local("/Users/moky/Applications/Android Studio Koala Feature Drop 2024.1.2 Patch 1.app/Contents")
+        } else {
+            // Use recommended IDE for CI builds
+            intellijIdeaCommunity("2022.3")
+        }
 
         pluginVerifier()
         zipSigner()
-
         testFramework(TestFrameworkType.Platform)
     }
 }
@@ -100,7 +108,8 @@ intellijPlatform {
     pluginConfiguration {
         ideaVersion {
             sinceBuild.set("223")
-            untilBuild.set("300.*")
+            // No upper limit - compatible with all future versions
+            untilBuild.set(provider { null })
         }
         changeNotes.set(customChangeNotes)
     }
@@ -131,6 +140,7 @@ intellijPlatform {
 tasks {
     runIde {
         autoReload.set(false) // Disable to avoid hot-reload-agent compatibility issues
+        maxHeapSize = "4096m"
         // Exclude the problematic hot-reload-agent from JVM args
         jvmArgumentProviders.removeIf {
             it.toString().contains("hot-reload") || it.toString().contains("HotReload")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,5 @@
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx2048m
 # Kotlin stdlib configuration
 kotlin.stdlib.default.dependency=false
+# Enable Configuration Cache
+org.gradle.configuration-cache=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/cc/moky/intellij/plugin/svga/SvgaFileEditorProvider.kt
+++ b/src/main/kotlin/cc/moky/intellij/plugin/svga/SvgaFileEditorProvider.kt
@@ -6,14 +6,55 @@ package cc.moky.intellij.plugin.svga
  * Mail: mokyue@163.com
  *******************************************************************************/
 
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorPolicy
 import com.intellij.openapi.fileEditor.FileEditorProvider
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.jcef.JBCefApp
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Flag to ensure the JCEF warning dialog is shown only once per IDE session.
+ * Using AtomicBoolean for thread safety as accept() may be called from multiple threads.
+ */
+private val jcefWarningShown = AtomicBoolean(false)
+
+/**
+ * Possible Action IDs for the "Choose Boot Java Runtime" dialog.
+ * Different IDE versions may use different action IDs.
+ */
+private val CHOOSE_RUNTIME_ACTION_IDS = arrayOf(
+    "ChooseRuntime",                               // Most common ID (Choose Runtime plugin)
+    "ChooseBootRuntime",                           // Alternative ID
+    "ChooseBootJavaRuntimeAction",                 // Legacy ID
+    "com.intellij.ide.actions.ChooseRuntimeAction" // Full qualified name
+)
 
 internal class SvgaFileEditorProvider : FileEditorProvider, DumbAware {
+
+    companion object {
+        private val LOG = Logger.getInstance(SvgaFileEditorProvider::class.java)
+
+        private const val DIALOG_TITLE = "JCEF Not Available"
+        private const val DIALOG_MESSAGE = """SVGA preview requires JCEF which is not available in your current runtime.
+
+Please switch to a JetBrains Runtime (JBR) with JCEF support."""
+        private const val BUTTON_CHANGE_JBR = "Change JBR"
+        private const val BUTTON_CANCEL = "Cancel"
+
+        private const val FALLBACK_MESSAGE = """Could not open JBR selection dialog automatically.
+
+Please go to: Help → Find Action → type "Choose Runtime" and select a JetBrains Runtime with JCEF support."""
+    }
 
     /**
      * The method is expected to run fast.
@@ -22,7 +63,65 @@ internal class SvgaFileEditorProvider : FileEditorProvider, DumbAware {
      * @return `true` if provider can create valid editor for the specified `file`.
      */
     override fun accept(project: Project, file: VirtualFile): Boolean {
-        return file.fileType is SvgaFileType
+        // Only process SVGA files
+        if (file.fileType !is SvgaFileType) {
+            return false
+        }
+
+        // Check if JCEF is available
+        if (!JBCefApp.isSupported()) {
+            // Show warning dialog only once per session
+            if (jcefWarningShown.compareAndSet(false, true)) {
+                showJcefWarningDialog()
+            }
+            return true
+        }
+
+        return true
+    }
+
+    /**
+     * Shows a warning dialog informing the user that JCEF is not available.
+     * Provides a "Change JBR" button to open the JBR selection dialog.
+     * Must be called on EDT.
+     */
+    private fun showJcefWarningDialog() {
+        // Ensure dialog is shown on EDT
+        ApplicationManager.getApplication().invokeLater {
+            val result = Messages.showOkCancelDialog(
+                DIALOG_MESSAGE, DIALOG_TITLE, BUTTON_CHANGE_JBR, BUTTON_CANCEL, Messages.getWarningIcon()
+            )
+
+            if (result == Messages.OK) {
+                openChooseBootRuntimeDialog()
+            }
+        }
+    }
+
+    /**
+     * Opens the "Choose Boot Java Runtime for the IDE" dialog.
+     * Tries multiple possible action IDs as different IDE versions may use different IDs.
+     * Shows a fallback message if no action is found.
+     */
+    private fun openChooseBootRuntimeDialog() {
+        val actionManager = ActionManager.getInstance()
+
+        // Try each possible action ID
+        for (actionId in CHOOSE_RUNTIME_ACTION_IDS) {
+            val action = actionManager.getAction(actionId)
+            if (action != null) {
+                LOG.info("Found Choose Runtime action with ID: $actionId")
+                val event = AnActionEvent.createFromDataContext(
+                    "SvgaFileEditorProvider", Presentation(), DataContext.EMPTY_CONTEXT
+                )
+                action.actionPerformed(event)
+                return
+            }
+        }
+
+        // No action found, show fallback message
+        LOG.warn("No Choose Runtime action found. Tried: ${CHOOSE_RUNTIME_ACTION_IDS.contentToString()}")
+        Messages.showInfoMessage(FALLBACK_MESSAGE, "Manual Action Required")
     }
 
     /**

--- a/src/main/kotlin/cc/moky/intellij/plugin/svga/SvgaFileType.kt
+++ b/src/main/kotlin/cc/moky/intellij/plugin/svga/SvgaFileType.kt
@@ -9,13 +9,7 @@ package cc.moky.intellij.plugin.svga
 import com.intellij.openapi.fileTypes.LanguageFileType
 import javax.swing.Icon
 
-class SvgaFileType private constructor() : LanguageFileType(Svga.INSTANCE) {
-
-    companion object {
-
-        @JvmField
-        val INSTANCE = SvgaFileType()
-    }
+object SvgaFileType : LanguageFileType(Svga.INSTANCE) {
 
     /**
      * Returns the name of the file type. The name must be unique among all file types registered in the system.


### PR DESCRIPTION
1. Upgrade Gradle from 8.13 to 9.0.0 and enable configuration caching to optimize build performance.
2. Upgrade Kotlin from 2.0.21 to 2.2.0.
3. Add JCEF support detection and user prompts to guide users to switch to JBR, which supports JCEF, when JCEF is unavailable.
4. Improve IDE compatibility settings and remove the upper limit to support future versions.
5. Optimize development environment configuration, add custom IDE options, and increase IDE runtime memory.