### PR TITLE
fix: Fix deprecated API usage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,10 @@ group = "cc.moky.intellij.plugin"
 version = providers.environmentVariable("VERSION_TAG").orElse("0.0.1-beta1").get()
 
 val customChangeNotes = """
+<strong>Changes in version 1.1.2:</strong>
+<ul>
+<li>Fix deprecated API usage.</li>
+</ul>
 <strong>Changes in version 1.1.1:</strong>
 <ul>
 <li>Add JCEF support detection and user prompts to guide users to switch to JBR, which supports JCEF, when JCEF is unavailable.</li>


### PR DESCRIPTION
Fix deprecated API usage, replace AnActionEvent.createFromDataContext() and AnAction.actionPerformed() with ActionManager.tryToExecute() to comply with IntelliJ Platform API contracts.