### PR TITLE
fix: Fix deprecated API usage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,10 @@ group = "cc.moky.intellij.plugin"
 version = providers.environmentVariable("VERSION_TAG").orElse("0.0.1-beta1").get()
 
 val customChangeNotes = """
+<strong>Changes in version 1.1.3:</strong>
+<ul>
+<li>Fix deprecated API usage.</li>
+</ul>
 <strong>Changes in version 1.1.2:</strong>
 <ul>
 <li>Fix deprecated API usage.</li>


### PR DESCRIPTION
1. Update the `showJcefWarningDialog()` method to accept the `project` parameter for proper dialog positioning.
2. Replace the outdated `ActionUtil.invokeAction()` method with the recommended `ActionManager.tryToExecute()`.